### PR TITLE
Enable usage on mobile

### DIFF
--- a/src/main/java/com/arcbees/analytics/client/ClientAnalytics.java
+++ b/src/main/java/com/arcbees/analytics/client/ClientAnalytics.java
@@ -207,16 +207,9 @@ public class ClientAnalytics extends AnalyticsImpl {
             }, i[r].l = 1 * new Date();
             a = s.createElement(o), m = s.getElementsByTagName(o)[0];
             a.async = 1;
-            // If current protocol is "file" we are on mobile
-            // So we explicitly specify https protocol for the script's source link
-            if ($wnd.location.protocol === "file:") {
-            	// CHECKSTYLE_OFF
-                g = "https:" + g;
-                // CHECKSTYLE_ON
-            }
             a.src = g;
             m.parentNode.insertBefore(a, m)
-        })($wnd, $doc, 'script', '//www.google-analytics.com/analytics.js',
+        })($wnd, $doc, 'script', 'https://www.google-analytics.com/analytics.js',
                 '__ua');
     }-*/;
 

--- a/src/main/java/com/arcbees/analytics/client/ClientAnalytics.java
+++ b/src/main/java/com/arcbees/analytics/client/ClientAnalytics.java
@@ -207,6 +207,13 @@ public class ClientAnalytics extends AnalyticsImpl {
             }, i[r].l = 1 * new Date();
             a = s.createElement(o), m = s.getElementsByTagName(o)[0];
             a.async = 1;
+            // If current protocol is "file" we are on mobile
+            // So we explicitly specify https protocol for the script's source link
+            if ($wnd.location.protocol === "file:") {
+            	// CHECKSTYLE_OFF
+                g = "https:" + g;
+                // CHECKSTYLE_ON
+            }
             a.src = g;
             m.parentNode.insertBefore(a, m)
         })($wnd, $doc, 'script', '//www.google-analytics.com/analytics.js',


### PR DESCRIPTION
This PR is a proposal to enable the usage of universal-analytics on mobile. The problem that it tries to solve is the use of protocol-relative URL [here](https://github.com/ArcBees/universal-analytics/blob/master/src/main/java/com/arcbees/analytics/client/ClientAnalytics.java#L212) which on mobile WebView is replaced by `file://`and renders it impossible to fetch the analytics.js lib.