### PR TITLE
Add helper methods for sending ScreenView HitType

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ analytics.enablePlugin(AnalyticsPlugin.DISPLAY); // (optional) Provides demograp
 analytics.sendPageView().go(); // (recommended) track the initial pageview
 ```
 
+##Mobile Install
+
+When running in mobile applications under `file:` protocol, there is no cookie for UA to store
+the data, thus there are some aditional steps on mobile:
+1. Disable cookies storage
+2. Set a clientId
+
+[More details here](https://developers.google.com/analytics/devguides/collection/analyticsjs/domains#disableCookies)
+
+It can be done as follows:
+
+```
+createOpts = analytics.create(trackerCode);
+createOpts.clientId('client_id').storage(Storage.NONE).go();
+```
+
 ##Basic Usage
 
 Inject Analytics into the class you want to track events from.
@@ -57,14 +73,26 @@ analytics.sendPageView().documentPath("/foo").go(); //track a pageview for page 
 analytics.sendEvent("button", "click").eventLabel("my label").go(); //send event with label
 ```
 
-If you want to change the global settings call setGlobalSettings in the same way. 
+If you want to change the global settings call setGlobalSettings in the same way.
 ```
 analytics.setGlobalSettings().anonymizeIp(true).go(); //anonymize ips
 ```
 
+##Mobile Usage
+
+When dealing with mobile analytics the [ScreenView
+events should be used instead of PageView](https://developers.google.com/analytics/devguides/collection/analyticsjs/screens).
+It's also mandatory to send `AppName` otherwise the realtime analytics won't work.
+Another useful information to send is the ScreenName.
+
+e.g.:
+```
+analytics.sendScreenView().screenName('current_page_name')
+.appTrackingOptions()
+.applicationName('my_app_name').go();
+```
+
 ##Server Side
-
-
 
 ```
 install(new ServerAnalyticsModule("UA-XXXXXX-X"));

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ analytics.sendPageView().go(); // (recommended) track the initial pageview
 ##Mobile Install
 
 When running in mobile applications under `file:` protocol, there is no cookie for UA to store
-the data, thus there are some aditional steps on mobile:
-1. Disable cookies storage
-2. Set a clientId
+the data, thus there are some additional steps on mobile:
+1. Set autoCreate to false (instructions in "Advanced Install" section)
+2. Disable cookies storage
+3. Set a clientId (should represent a unique user)
+4. Disable protocol check (otherwise it aborts when protocol is not http/https)
 
 [More details here](https://developers.google.com/analytics/devguides/collection/analyticsjs/domains#disableCookies)
 
@@ -56,6 +58,7 @@ It can be done as follows:
 ```
 createOpts = analytics.create(trackerCode);
 createOpts.clientId('client_id').storage(Storage.NONE).go();
+analytics.setGlobalSettings().generalOptions().disableTask(Task.CHECK_PROTOCOL).go();
 ```
 
 ##Basic Usage
@@ -87,9 +90,7 @@ Another useful information to send is the ScreenName.
 
 e.g.:
 ```
-analytics.sendScreenView().screenName('current_page_name')
-.appTrackingOptions()
-.applicationName('my_app_name').go();
+analytics.sendScreenView().screenName('current_page_name').appTrackingOptions().applicationName('my_app_name').go();
 ```
 
 ##Server Side

--- a/src/main/java/com/arcbees/analytics/shared/Analytics.java
+++ b/src/main/java/com/arcbees/analytics/shared/Analytics.java
@@ -162,8 +162,7 @@ public interface Analytics {
     ContentOptions sendPageView(String trackerName);
 
     /**
-     * send a screenview for moobile configured analytics. Should be used
-     * with screenName option.
+     * Send a screenview for mobile configured analytics. Should be used with screenName option.
      * @see <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/screens">App/Screen UA</a>
      * 
      * Example: sendScreenView().screenName("my_screen_name").go();
@@ -171,8 +170,7 @@ public interface Analytics {
     ContentOptions sendScreenView();
 
     /**
-     * send a screenview to specific tracker. Should be used
-     * with screenName option.
+     * Send a screenview to specific tracker. Should be used with screenName option.
      * @see <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/screens">App/Screen UA</a>
      * 
      * Example: sendScreenView('my_tracker_name').screenName("my_screen_name").go();

--- a/src/main/java/com/arcbees/analytics/shared/Analytics.java
+++ b/src/main/java/com/arcbees/analytics/shared/Analytics.java
@@ -162,6 +162,24 @@ public interface Analytics {
     ContentOptions sendPageView(String trackerName);
 
     /**
+     * send a screenview for moobile configured analytics. Should be used
+     * with screenName option.
+     * @see <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/screens">App/Screen UA</a>
+     * 
+     * Example: sendScreenView().screenName("my_screen_name").go();
+     */
+    ContentOptions sendScreenView();
+
+    /**
+     * send a screenview to specific tracker. Should be used
+     * with screenName option.
+     * @see <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/screens">App/Screen UA</a>
+     * 
+     * Example: sendScreenView('my_tracker_name').screenName("my_screen_name").go();
+     */
+    ContentOptions sendScreenView(String trackerName);
+
+    /**
      * send a social event.
      *
      * @param socialNetwork

--- a/src/main/java/com/arcbees/analytics/shared/AnalyticsImpl.java
+++ b/src/main/java/com/arcbees/analytics/shared/AnalyticsImpl.java
@@ -82,6 +82,16 @@ public abstract class AnalyticsImpl implements Analytics {
     }
 
     @Override
+    public ContentOptions sendScreenView() {
+        return sendScreenView(null);
+    }
+
+    @Override
+    public ContentOptions sendScreenView(String trackerName) {
+        return send(trackerName, HitType.SCREEN_VIEW).contentOptions();
+    }
+
+    @Override
     public SocialOptions sendSocial(String socialNetwork, String socialAction,
             String socialTarget) {
         return sendSocial(null, socialNetwork, socialAction, socialTarget);


### PR DESCRIPTION
In order to have better Analytics view for mobile apps, the apps should send ScreenView hit instead of PageView. This PR creates a helper method to send the ScreenView hit.