### PR TITLE
Make tracker names and timing events request scoped.

### DIFF
--- a/src/main/java/com/arcbees/analytics/server/ServerAnalytics.java
+++ b/src/main/java/com/arcbees/analytics/server/ServerAnalytics.java
@@ -16,7 +16,6 @@
 
 package com.arcbees.analytics.server;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -39,8 +38,6 @@ public class ServerAnalytics extends AnalyticsImpl {
     private static final Logger LOGGER = Logger.getLogger(ServerAnalytics.class.getName());
 
     private final Provider<ServerOptionsCallback> serverOptionsCallbackProvider;
-    private final Map<String, Long> timingEvents = new HashMap<>();
-    private final Map<String, String> trackerNames = new HashMap<>();
 
     @Inject
     ServerAnalytics(
@@ -53,6 +50,7 @@ public class ServerAnalytics extends AnalyticsImpl {
 
     @Override
     public CreateOptions create(final String userAccount) {
+        final Map<String, String> trackerNames = serverOptionsCallbackProvider.get().getTrackerNames();
         return new AnalyticsOptions(new TrackerNameOptionsCallback() {
 
             @Override
@@ -70,6 +68,7 @@ public class ServerAnalytics extends AnalyticsImpl {
     @Override
     public TimingOptions endTimingEvent(String trackerName, String timingCategory,
             String timingVariableName) {
+        Map<String, Long> timingEvents = serverOptionsCallbackProvider.get().getTimingEvents();
         final String key = getTimingKey(timingCategory, timingVariableName);
         if (timingEvents.containsKey(key)) {
             return sendTiming(trackerName, timingCategory, timingVariableName,
@@ -91,6 +90,7 @@ public class ServerAnalytics extends AnalyticsImpl {
     @Override
     public AnalyticsOptions send(String trackerName, HitType hitType) {
         final ServerOptionsCallback options = serverOptionsCallbackProvider.get();
+        final Map<String, String> trackerNames = options.getTrackerNames();
         if (trackerName != null) {
             options.putText("tid", trackerNames.get(trackerName));
         }
@@ -112,6 +112,7 @@ public class ServerAnalytics extends AnalyticsImpl {
 
     @Override
     public void startTimingEvent(String timingCategory, String timingVariableName) {
+        Map<String,Long> timingEvents = serverOptionsCallbackProvider.get().getTimingEvents();
         timingEvents.put(getTimingKey(timingCategory, timingVariableName),
                 System.currentTimeMillis());
     }

--- a/src/main/java/com/arcbees/analytics/server/options/ServerOptionsCallback.java
+++ b/src/main/java/com/arcbees/analytics/server/options/ServerOptionsCallback.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,8 +37,8 @@ public class ServerOptionsCallback extends OptionsCallback<String> {
     private static final String POST_URL = "https://www.google-analytics.com/collect";
 
     private Map<String, String> options = new ConcurrentHashMap<>();
-    private final Map<String, Long> timingEvents = new HashMap<>();
-    private final Map<String, String> trackerNames = new HashMap<>();
+    private final Map<String, Long> timingEvents = new ConcurrentHashMap<>();
+    private final Map<String, String> trackerNames = new ConcurrentHashMap<>();
 
     @Override
     public void addHitCallback(HitCallback hitCallback) {

--- a/src/main/java/com/arcbees/analytics/server/options/ServerOptionsCallback.java
+++ b/src/main/java/com/arcbees/analytics/server/options/ServerOptionsCallback.java
@@ -23,6 +23,7 @@ import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -36,7 +37,9 @@ public class ServerOptionsCallback extends OptionsCallback<String> {
     private static final Logger LOGGER = Logger.getLogger(ServerOptionsCallback.class.getName());
     private static final String POST_URL = "https://www.google-analytics.com/collect";
 
-    private Map<String, String> options = new HashMap<>();
+    private Map<String, String> options = new ConcurrentHashMap<>();
+    private final Map<String, Long> timingEvents = new HashMap<>();
+    private final Map<String, String> trackerNames = new HashMap<>();
 
     @Override
     public void addHitCallback(HitCallback hitCallback) {
@@ -97,5 +100,13 @@ public class ServerOptionsCallback extends OptionsCallback<String> {
 
             return value;
         }
+    }
+
+    public Map<String, Long> getTimingEvents() {
+        return timingEvents;
+    }
+
+    public Map<String, String> getTrackerNames() {
+        return trackerNames;
     }
 }

--- a/src/main/java/com/arcbees/analytics/server/options/TrackerNameOptionsCallback.java
+++ b/src/main/java/com/arcbees/analytics/server/options/TrackerNameOptionsCallback.java
@@ -16,14 +16,14 @@
 
 package com.arcbees.analytics.server.options;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.arcbees.analytics.shared.HitCallback;
 import com.arcbees.analytics.shared.options.OptionsCallback;
 
 public abstract class TrackerNameOptionsCallback extends OptionsCallback<String> {
-    private Map<String, String> options = new HashMap<>();
+    private Map<String, String> options = new ConcurrentHashMap<>();
 
     @Override
     public void addHitCallback(HitCallback hitCallback) {


### PR DESCRIPTION
Use ConcurrentHashMap on server to allow for multithreaded HttpRequests
